### PR TITLE
Rename zig package to perfevent and add Usage&Troubleshooting to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
-`build.zig.zon`
+# PerfEvent
+A thin zig wrapper for Linux' perf event API.
+Inspired by https://github.com/viktorleis/perfevent
+
+## Import
+1) Run the following command:
+`zig fetch --save https://github.com/toziegler/zig-perfevent/archive/refs/heads/main.tar.gz`
+or add the following snippet to `build.zig.zon`:
 ```zig
     .dependencies = .{
         .perfevent = .{
@@ -16,3 +23,27 @@
     });
     exe.root_module.addImport("perfevent", perfevent.module("perfevent"));
 ```
+## Usage
+```zig
+pub fn main() !void {
+   const scale: u64 = 10000;
+    {
+       var perf = perfevent.PerfEventBlock.init(scale, true);
+       defer perf.deinit();
+       for (0..scale) |_| {
+          try do_operation();
+       }
+    }
+}
+
+```
+
+This prints something like this:
+```csv
+wall_time,utime,stime,cpu_cycles,instructions,cache_references,cache_misses,branch_misses,CPUs,GHZ,maxrss_mb,scale
+82405439,82361000,0,305.68,732.06,1.67,0.43,0.27,1.00,3.71,16,1000000
+```
+
+## Troubleshooting
+
+You may need to run sudo sysctl -w kernel.perf_event_paranoid=-1 and/or add kernel.perf_event_paranoid = -1 to /etc/sysctl.conf

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -6,7 +6,7 @@
     //
     // It is redundant to include "zig" in this name because it is already
     // within the Zig package namespace.
-    .name = "perf",
+    .name = "perfevent",
 
     // This is a [Semantic Version](https://semver.org/).
     // In a future version of Zig it will be used for package deduplication.


### PR DESCRIPTION
As mentioned in title:
1) Rename zig package to match `build.zig.zon` snippet in readme
2) Improve README to include Usage and Troubleshooting section